### PR TITLE
fix: decode utf8 characters to show glyphs properly

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -75,7 +75,14 @@ local function generate_widgets(modules, box) --{{{
   end
 end --}}}
 
+local function utf8_decode(str)
+  return str:gsub("\\u(%x%x%x%x)", function(hex)
+    return utf8.char(tonumber(hex, 16))
+     end)
+end
+
 local function parse_json(json_str, box) --{{{
+  json_str = utf8_decode(json_str)
   -- create the array that will be filled with the data from the json output and the iterator
   local modules = {}
   local module_itr = 1 -- lua arrays actually start at anything you want btw


### PR DESCRIPTION
I recently switched to awesomewm from DWM/dwmbar and ran across this when trying to populate my status bar with py3status I had previously installed with sway. This definitely saved me some time.

The only issue I had was it wasn't properly escaping unicode glyphs

![image](https://github.com/user-attachments/assets/d4cca380-33d4-47e0-b266-f747d3aaa2b5)


After: 
![image](https://github.com/user-attachments/assets/5d20a983-8918-4136-914e-635768050078)


EDIT: removed formatting responsible for the huge diff